### PR TITLE
Changed Gambia,The and Bahamas,The to "The .."

### DIFF
--- a/data/country/countries.tsv
+++ b/data/country/countries.tsv
@@ -200,3 +200,5 @@ YE	1990-05-22		Yemen	The Republic of Yemen	Yemeni
 ZM			Zambia	The Republic of Zambia	Zambian
 ZW	1980-04-18		Zimbabwe	The Republic of Zimbabwe	Zimbabwean
 GM			Gambia,The	The Islamic Republic of The Gambia	Gambian
+GM			The Gambia	The Islamic Republic of The Gambia	Gambian
+BS			The Bahamas	The Commonwealth of The Bahamas	Bahamian


### PR DESCRIPTION
The ',The' convention crept into the name field as we prepared for launch.

This is not a convention we want to establish for names of companies, schools, charities, etc. Consumers who need to sort county names ignoring definite or indefinite articles will should transform the data before performing their collation, which may have domain specific rules.

This change has been agreed with the custodian, but may have impact on epetitions and other services using the country register.

The data for the new entries has been appended to the tsv of country records.
