### PR TITLE
Uk and territories

### DIFF
--- a/data/country/countries.tsv
+++ b/data/country/countries.tsv
@@ -200,3 +200,5 @@ YE	1990-05-22		Yemen	The Republic of Yemen	Yemeni
 ZM			Zambia	The Republic of Zambia	Zambian
 ZW	1980-04-18		Zimbabwe	The Republic of Zimbabwe	Zimbabwean
 GM			Gambia,The	The Islamic Republic of The Gambia	Gambian
+GM			The Gambia	The Islamic Republic of The Gambia	Gambian
+BS			The Bahamas	The Commonwealth of The Bahamas	Bahamian

--- a/data/territory/territories.tsv
+++ b/data/territory/territories.tsv
@@ -35,6 +35,3 @@ FO			Faroe Islands	Faroe Islands		Autonomous country within the Danish Realm
 GL			Greenland	Greenland		Autonomous country within the Danish Realm
 AX			Åland Islands	Åland Islands		Autonomous region of Finland
 SJ			Svalbard and Jan Mayen	Svalbard and Jan Mayen		Unincorporated area administered by Norway
-GG			Guernsey	Bailiwick of Guernsey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
-JE			Jersey	Bailiwick of Jersey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
-IM			Isle of Man	Isle of Man		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.

--- a/data/territory/territories.tsv
+++ b/data/territory/territories.tsv
@@ -12,7 +12,7 @@ BL			Saint Barthélemy	Saint Barthélemy		Overseas collectivity of France
 NC			New Caledonia	New Caledonia		Special collectivity of France
 TF			French Southern Territories	French Southern Territories		
 HK			Hong Kong	Hong Kong Special Administrative Region		
-MO			Macau	Macau Special Administrative Region		
+MO			Macao	Macau Special Administrative Region		
 TW			Taiwan	Taiwan	Taiwanese	
 EH			Western Sahara	Western Sahara		
 PS			Occupied Palestinian Territories	The Occupied Palestinian Territories	Palestinian or Israeli (as appropriate)	
@@ -24,7 +24,7 @@ GU			Guam	Territory of Guam		Unincorporated and organized territory of the Unite
 MP			Northern Mariana Islands	Commonwealth of the Northern Mariana Islands		Commonwealth in political union with the U.S
 PR			Puerto Rico	Commonwealth of Puerto Rico		United States territory
 VI			U. S. Virgin Islands	Virgin Islands of the United States		Unincorporated territory of the United States
-AS			American Samao	Territory of American Samoa		Unincorporated territory of the United States
+AS			American Samoa	Territory of American Samoa		Unincorporated territory of the United States
 TK			Tokelau	Tokelau		Territory of New Zealand
 BV			Bouvet Island	Bouvet Island		Dependency of Norway
 CX			Christmas Island	Territory of Christmas Island		External territory of Australia

--- a/data/territory/territories.tsv
+++ b/data/territory/territories.tsv
@@ -1,18 +1,40 @@
-territory	start-date	end-date	name	official-name	citizen-names
-AKROTIRI			Akrotiri	Akrotiri	
-AI			Anguilla	Anguilla	Anguillan
-BM			Bermuda	Bermuda	Bermudan
-BAT			British Antarctic Territory	British Antarctic Territory	
-IO			British Indian Ocean Territory	The British Indian Ocean Territory	
-VG			The Virgin Islands	British Virgin Islands	British Virgin Islander
-KY			Cayman Islands	Cayman Islands	Cayman Islander;Caymanian
-DHEKELIA			Dhekelia	Dhekelia	
-FK			Falkland Islands	Falkland Islands	Falkland Islander
-GI			Gibraltar	Gibraltar	Gibraltarian
-MS			Montserrat	Montserrat	Montserratian;Montserratian
-PN			Pitcairn, Henderson, Ducie and Oeno Islands	Pitcairn, Henderson, Ducie and Oeno Islands	Pitcairn Islander;Pitcairner
-SH			St Helena, Ascension and Tristan da Cunha	St Helena, Ascension and Tristan da Cunha	St Helenian;Tristanian
-GS			South Georgia and South Sandwich Islands	South Georgia and the South Sandwich Islands	
-TC			Turks and Caicos Islands	Turks and Caicos Islands	Turks and Caicos Islander
-PL			Occupied Palestinian Territories	The Occupied Palestinian Territories	Palestiniani;Israeli
-TW			Taiwan	Taiwan	Taiwanese
+territory	start-date	end-date	name	official-name	citizen-names	text
+GF			French Guiana	French Guiana		Overseas department of France
+GP			Guadeloupe	Guadeloupe		Overseas department of France
+MQ			Martinique	Martinique		Overseas department of France
+RE			Réunion	Réunion		Overseas department of France
+YT			Mayotte	Mayotte		Overseas department of France
+PF			French Polynesia	French Polynesia		Overseas collectivity of France
+PM			Saint Pierre and Miquelon	Saint Pierre and Miquelon		Overseas collectivity of France
+WF			Wallis and Futuna	Wallis and Futuna		Overseas collectivity of France
+MF			Saint Martin	Saint Martin		Overseas collectivity of France
+BL			Saint Barthélemy	Saint Barthélemy		Overseas collectivity of France
+NC			New Caledonia	New Caledonia		Special collectivity of France
+TF			French Southern Territories	French Southern Territories		
+HK			Hong Kong	Hong Kong Special Administrative Region		
+MO			Macau	Macau Special Administrative Region		
+TW			Taiwan	Taiwan	Taiwanese	
+EH			Western Sahara	Western Sahara		
+PS			Occupied Palestinian Territories	The Occupied Palestinian Territories	Palestinian or Israeli (as appropriate)	
+AW			Aruba	Aruba		Constituent country of the Kingdom of the Netherlands
+CW			Curaçao	Curaçao		Constituent country of the Kingdom of the Netherlands
+BQ			Bonaire, Sint Eustatius and Saba	Bonaire, Sint Eustatius and Saba		Special municipality of the Netherlands
+SX			Sint Maarten (Dutch part)	Sint Maarten (Dutch part)		Constituent country of the Kingdom of the Netherlands
+GU			Guam	Territory of Guam		Unincorporated and organized territory of the United States
+MP			Northern Mariana Islands	Commonwealth of the Northern Mariana Islands		Commonwealth in political union with the U.S
+PR			Puerto Rico	Commonwealth of Puerto Rico		United States territory
+VI			U. S. Virgin Islands	Virgin Islands of the United States		Unincorporated territory of the United States
+AS			American Samao	Territory of American Samoa		Unincorporated territory of the United States
+TK			Tokelau	Tokelau		Territory of New Zealand
+BV			Bouvet Island	Bouvet Island		Dependency of Norway
+CX			Christmas Island	Territory of Christmas Island		External territory of Australia
+CC			Cocos (Keeling) Islands	Territory of the Cocos (Keeling) Islands		External territory of Australia
+NF			Norfolk Island	Territory of Norfolk Island		External territory of Australia
+HM			Heard Island and McDonald Islands	Territory of Heard Island and McDonald Islands		External territory of Australia
+FO			Faroe Islands	Faroe Islands		Autonomous country within the Danish Realm
+GL			Greenland	Greenland		Autonomous country within the Danish Realm
+AX			Åland Islands	Åland Islands		Autonomous region of Finland
+SJ			Svalbard and Jan Mayen	Svalbard and Jan Mayen		Unincorporated area administered by Norway
+GG			Guernsey	Bailiwick of Guernsey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
+JE			Jersey	Bailiwick of Jersey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
+IM			Isle of Man	Isle of Man		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.

--- a/data/uk/uk.tsv
+++ b/data/uk/uk.tsv
@@ -19,3 +19,6 @@ PN			Pitcairn, Henderson, Ducie and Oeno Islands	Pitcairn, Henderson, Ducie and 
 SH			St Helena, Ascension and Tristan da Cunha	St Helena, Ascension and Tristan da Cunha	St Helenian;Tristanian	United Kingdom Overseas Territory
 GS			South Georgia and South Sandwich Islands	South Georgia and the South Sandwich Islands		United Kingdom Overseas Territory
 TC			Turks and Caicos Islands	Turks and Caicos Islands	Turks and Caicos Islander	United Kingdom Overseas Territory
+GG			Guernsey	Bailiwick of Guernsey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
+JE			Jersey	Bailiwick of Jersey		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.
+IM			Isle of Man	Isle of Man		Crown Dependency which is not part of the UK but is a self-governing Dependency of the Crown.

--- a/data/uk/uk.tsv
+++ b/data/uk/uk.tsv
@@ -1,8 +1,21 @@
-uk	start-date	end-date	name	official-name	citizen-names
-ENG			England	England	English
-SCT			Scotland	Scotland	Scottish
-WLS			Wales	Wales	Welsh
-NIR			Northern Ireland	Northern Ireland	Northern Irish
-GBG			Guernsey	Bailiwick of Guernsey	
-JEY			Jersey	Bailiwick of Jersey	
-GBM			Isle of Man	Isle of Man	
+uk	start-date	end-date	name	official-name	citizen-names	text
+GBN			Great Britain	Great Britain	Briton;British citizen	
+ENG			England	England	English	Country
+SCT			Scotland	Scotland	Scottish	Country
+WLS			Wales	Wales	Welsh	Country
+NIR			Northern Ireland	Northern Ireland	Northern Irish	Province
+AX00			Akrotiri	Akrotiri		United Kingdom Overseas Territory
+AI			Anguilla	Anguilla	Anguillan	United Kingdom Overseas Territory
+BM			Bermuda	Bermuda	Bermudan	United Kingdom Overseas Territory
+ATB			British Antarctic Territory	British Antarctic Territory		United Kingdom Overseas Territory
+IO			British Indian Ocean Territory	The British Indian Ocean Territory		United Kingdom Overseas Territory
+VG			The Virgin Islands	British Virgin Islands	British Virgin Islander	United Kingdom Overseas Territory
+KY			Cayman Islands	Cayman Islands	Cayman Islander;Caymanian	United Kingdom Overseas Territory
+DX00			Dhekelia	Dhekelia		United Kingdom Overseas Territory
+FK			Falkland Islands	Falkland Islands	Falkland Islander	United Kingdom Overseas Territory
+GI			Gibraltar	Gibraltar	Gibraltarian	United Kingdom Overseas Territory
+MS			Montserrat	Montserrat	Montserratian;Montserratian	United Kingdom Overseas Territory
+PN			Pitcairn, Henderson, Ducie and Oeno Islands	Pitcairn, Henderson, Ducie and Oeno Islands	Pitcairn Islander;Pitcairner	United Kingdom Overseas Territory
+SH			St Helena, Ascension and Tristan da Cunha	St Helena, Ascension and Tristan da Cunha	St Helenian;Tristanian	United Kingdom Overseas Territory
+GS			South Georgia and South Sandwich Islands	South Georgia and the South Sandwich Islands		United Kingdom Overseas Territory
+TC			Turks and Caicos Islands	Turks and Caicos Islands	Turks and Caicos Islander	United Kingdom Overseas Territory


### PR DESCRIPTION
New data for the UK and Territory registers.

Please hold off merging until we've approval from Tony/FCO.

We need to clear moving the Bailiwicks and Isle of Man into the "UK" register, if we're clear the UK register of UK countries, provinces, overseas territories and crown dependencies.
