### PR TITLE
Respell Cote D'Ivoire as Côte D’Ivoire

### DIFF
--- a/data/country/countries.tsv
+++ b/data/country/countries.tsv
@@ -88,7 +88,6 @@ IQ			Iraq	The Republic of Iraq	Iraqi
 IE			Ireland	Ireland	Citizen of Ireland;Irish citizen
 IL			Israel	The State of Israel	Israeli
 IT			Italy	The Italian Republic	Italian
-CI			Ivory Coast	The Republic of Cote D'Ivoire	Citizen of the Ivory Coast
 JM			Jamaica	Jamaica	Jamaican
 JP			Japan	Japan	Japanese
 JO			Jordan	The Hashemite Kingdom of Jordan	Jordanian
@@ -205,3 +204,4 @@ BS			The Bahamas	The Commonwealth of The Bahamas	Bahamian
 VA			Vatican City	Vatican City State	Vatican citizen
 CZ	1993-01-01		Czechia	The Czech Republic	Czech
 GM			The Gambia	The Republic of The Gambia	Gambian
+CI			Ivory Coast	The Republic of Côte D’Ivoire	Citizen of the Ivory Coast


### PR DESCRIPTION
Confirmed by the custodian:

> The Country Name document’s “Official Name” field should be “The Republic of
> Côte D’Ivoire”.